### PR TITLE
Make nano exmaples port agnostic

### DIFF
--- a/examples/nano/autoscroll/.cargo/config.toml
+++ b/examples/nano/autoscroll/.cargo/config.toml
@@ -2,7 +2,7 @@
 target = "avr-specs/avr-atmega328p.json"
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude nano -cb 57600 --port=/dev/ttyUSB1"
+runner = "ravedude nano -cb 57600"
 
 [unstable]
 build-std = ["core"]

--- a/examples/nano/blink/.cargo/config.toml
+++ b/examples/nano/blink/.cargo/config.toml
@@ -2,7 +2,7 @@
 target = "avr-specs/avr-atmega328p.json"
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude nano -cb 57600 --port=/dev/ttyUSB1"
+runner = "ravedude nano -cb 57600"
 
 [unstable]
 build-std = ["core"]

--- a/examples/nano/character/.cargo/config.toml
+++ b/examples/nano/character/.cargo/config.toml
@@ -2,7 +2,7 @@
 target = "avr-specs/avr-atmega328p.json"
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude nano -cb 57600 --port=/dev/ttyUSB1"
+runner = "ravedude nano -cb 57600"
 
 [unstable]
 build-std = ["core"]

--- a/examples/nano/cursor/.cargo/config.toml
+++ b/examples/nano/cursor/.cargo/config.toml
@@ -2,7 +2,7 @@
 target = "avr-specs/avr-atmega328p.json"
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude nano -cb 57600 --port=/dev/ttyUSB1"
+runner = "ravedude nano -cb 57600"
 
 [unstable]
 build-std = ["core"]

--- a/examples/nano/display/.cargo/config.toml
+++ b/examples/nano/display/.cargo/config.toml
@@ -2,7 +2,7 @@
 target = "avr-specs/avr-atmega328p.json"
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude nano -cb 57600 --port=/dev/ttyUSB1"
+runner = "ravedude nano -cb 57600"
 
 [unstable]
 build-std = ["core"]

--- a/examples/nano/layout/.cargo/config.toml
+++ b/examples/nano/layout/.cargo/config.toml
@@ -2,7 +2,7 @@
 target = "avr-specs/avr-atmega328p.json"
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude nano -cb 57600 --port=/dev/ttyUSB1"
+runner = "ravedude nano -cb 57600"
 
 [unstable]
 build-std = ["core"]

--- a/examples/nano/position/.cargo/config.toml
+++ b/examples/nano/position/.cargo/config.toml
@@ -2,7 +2,7 @@
 target = "avr-specs/avr-atmega328p.json"
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude nano -cb 57600 --port=/dev/ttyUSB1"
+runner = "ravedude nano -cb 57600"
 
 [unstable]
 build-std = ["core"]

--- a/examples/nano/scroll/.cargo/config.toml
+++ b/examples/nano/scroll/.cargo/config.toml
@@ -2,7 +2,7 @@
 target = "avr-specs/avr-atmega328p.json"
 
 [target.'cfg(target_arch = "avr")']
-runner = "ravedude nano -cb 57600 --port=/dev/ttyUSB1"
+runner = "ravedude nano -cb 57600"
 
 [unstable]
 build-std = ["core"]


### PR DESCRIPTION
The Nano examples have a specific port set when `cargo run` is executed, which won't work unless they match (which isn't even certain if using the same OS as the one that they were developed on). This way, if `ravedude` is unable to find the port itself, it will at least print an error message stating the issue. 

I haven't been able to run the Nano examples on a Nano board, since I'm having issues with making `ravedude`/`avrdude` flash it, but I have been able to run it on an Uno by modifying the runner in .cargo/config.toml to `uno` instead of `nano`, since they use the same target.

What do you think?