### PR TITLE
Add builder method with_reliable_init()

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -35,4 +35,5 @@ Pins should be connected as follows (optional pins are commented in examples):
 
 # Troubleshooting
 * If your using a Nano board and recieve `avrdude: stk500_getsync() attempt 1 of 10: not in sync: resp=0x00` upon running `cargo run`, it might be because your board was manufactured after January 2018. In that case you'll need the new boot loader, which is achieved by changing `nano` to `nano-new` for `runner` in `.cargo/config.toml` in the example directory.
-* Regarding Arduino Uno: only setups using required pins have been tested to work; some users have reported issues with initializing the LCD (see [#4](https://github.com/mjhouse/ag-lcd/issues/4))
+* Regarding Arduino Uno: only setups using required pins have been tested to work
+* Some users have reported issues with initializing the LCD: try using the builder method `with_reliable_init()`, and see `examples/uno/two_lines/` for an example that implements it (see [#4](https://github.com/mjhouse/ag-lcd/issues/4) for further discussion).

--- a/examples/uno/two_lines/src/main.rs
+++ b/examples/uno/two_lines/src/main.rs
@@ -22,6 +22,7 @@ fn main() -> ! {
         .with_half_bus(d4, d5, d6, d7)
         .with_display(Display::On)
         .with_lines(ag_lcd::Lines::TwoLines)
+        .with_reliable_init(10000)
         .build();
 
     lcd.print_two_lines("Hello", "World");

--- a/src/display.rs
+++ b/src/display.rs
@@ -413,20 +413,33 @@ where
     /// delay in between, 3 times. A higher `delay_toggle` tends to make
     /// this method more reliable, and a value of `10 000` is recommended.
     /// Note that this method should be run as close as possible to
-    /// `.build()`, and that it leaves LCD with Display::On.
+    /// `.build()`.
     ///
+    /// # Examples
+    ///
+    /// ```
     /// let mut lcd: LcdDisplay<_,_> = LcdDisplay::new(rs, en, delay)
     ///     .with_half_bus(d4, d5, d6, d7)
     ///     .with_reliable_init(10000)
     ///     .build();
     /// ```
     pub fn with_reliable_init(mut self, delay_toggle: u16) -> Self {
-        for _ in 0..3 {
-            self.delay.delay_us(delay_toggle);
-            self.display_off();
-            self.delay.delay_us(delay_toggle);
-            self.display_on();
+        if self.display_ctrl == Display::On as u8 {
+            for _ in 0..3 {
+                self.delay.delay_us(delay_toggle);
+                self.display_off();
+                self.delay.delay_us(delay_toggle);
+                self.display_on();
+            }
+        } else {
+            for _ in 0..3 {
+                self.delay.delay_us(delay_toggle);
+                self.display_on();
+                self.delay.delay_us(delay_toggle);
+                self.display_off();
+            }
         }
+
         self
     }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -405,6 +405,31 @@ where
         self
     }
 
+    /// Increase reliability of initialization of LCD.
+    ///
+    /// Some users experience unreliable initialization of the LCD, where
+    /// the LCD sometimes is unable to display symbols after running
+    /// `.build()`. This method toggles the LCD off and on with some
+    /// delay in between, 3 times. A higher `delay_toggle` tends to make
+    /// this method more reliable, and a value of `10 000` is recommended.
+    /// Note that this method should be run as close as possible to
+    /// `.build()`, and that it leaves LCD with Display::On.
+    ///
+    /// let mut lcd: LcdDisplay<_,_> = LcdDisplay::new(rs, en, delay)
+    ///     .with_half_bus(d4, d5, d6, d7)
+    ///     .with_reliable_init(10000)
+    ///     .build();
+    /// ```
+    pub fn with_reliable_init(mut self, delay_toggle: u16) -> Self {
+        for _ in 0..3 {
+            self.delay.delay_us(delay_toggle);
+            self.display_off();
+            self.delay.delay_us(delay_toggle);
+            self.display_on();
+        }
+        self
+    }
+
     /// Finish construction of the LcdDisplay and initialized the
     /// display to the provided settings.
     ///
@@ -439,7 +464,7 @@ where
     /// ```
     pub fn build(mut self) -> Self {
         self.delay.delay_us(50000);
-        
+
         self.set(RS, false);
         self.set(EN, false);
 


### PR DESCRIPTION
This PR should somewhat fix issue #4, at least make a workaround available.

This PR adds a new builder method, `with_reliable_init()`, which toggles the screen off and on 3 times, with a user-set delay in between each toggle. I tried creating a workaround that only used a pause, without toggling the screen, but was unable to improve the system's behavior.

I see this as more of a workaround than as a solution, but a workaround that has been very useful for me. Because of that, I suggest we leave issue #4 open.