### PR TITLE
Support I2C interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,9 @@ exclude = ["media/*", "references/*"]
 [dependencies]
 embedded-hal = "0.2.3"
 ufmt = { version = "0.1.0", optional = true }
-port-expander = { version = "0.3" }
+port-expander = { version = "0.3", optional = true }
 shared-bus = "0.2"
 
 [features]
 avr-hal = []
+i2c = ["port-expander"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ exclude = ["media/*", "references/*"]
 [dependencies]
 embedded-hal = "0.2.3"
 ufmt = { version = "0.1.0", optional = true }
+port-expander = { version = "0.3" }
+shared-bus = "0.2"
 
 [features]
 avr-hal = []

--- a/src/display.rs
+++ b/src/display.rs
@@ -539,6 +539,18 @@ where
         self
     }
 
+    /// Turn backlight on
+    #[cfg(feature = "i2c")]
+    pub fn backlight_on(&mut self) {
+        let _ = self.backlight_pin.set_high();
+    }
+
+    /// Turn backlight off
+    #[cfg(feature = "i2c")]
+    pub fn backlight_off(&mut self) {
+        let _ = self.backlight_pin.set_low();
+    }
+
     /// Set the position of the cursor.
     ///
     /// # Examples

--- a/src/display.rs
+++ b/src/display.rs
@@ -141,6 +141,8 @@ where
     T: OutputPin<Error = Infallible> + Sized,
     D: DelayUs<u16> + Sized,
 {
+    #[cfg(feature = "i2c")]
+    backlight_pin: T,
     pins: [Option<T>; 11],
     display_func: u8,
     display_mode: u8,
@@ -179,7 +181,7 @@ where
     ///     .with_rw(d10) // optional (set lcd pin to GND if not provided)
     ///     .build();
     /// ```
-    pub fn new(rs: T, en: T, delay: D) -> Self {
+    pub fn new(rs: T, en: T, delay: D, #[cfg(feature = "i2c")] backlight_pin: T) -> Self {
         Self {
             pins: [
                 Some(rs),
@@ -194,6 +196,8 @@ where
                 None,
                 None,
             ],
+            #[cfg(feature = "i2c")]
+            backlight_pin,
             display_func: DEFAULT_DISPLAY_FUNC,
             display_mode: DEFAULT_DISPLAY_MODE,
             display_ctrl: DEFAULT_DISPLAY_CTRL,

--- a/src/display.rs
+++ b/src/display.rs
@@ -73,6 +73,15 @@ pub enum Blink {
     Off = 0x00, // LCD_BLINKOFF
 }
 
+/// Flag that sets backlight state
+pub enum Backlight {
+    /// Turn Backlight on (default)
+    On,
+
+    /// Turn Backlight off
+    Off,
+}
+
 /// Flag used to indicate direction for display scrolling
 #[repr(u8)]
 pub enum Scroll {
@@ -668,6 +677,14 @@ where
         }
         self.command(Command::SetDisplayCtrl as u8 | self.display_ctrl);
         self.delay.delay_us(CMD_DELAY);
+    }
+
+    /// Enable or disable LCD backlight
+    pub fn set_backlight(&mut self, backlight: Backlight) {
+        match backlight {
+            Backlight::On => self.blink_on(),
+            Backlight::Off => self.blink_off(),
+        }
     }
 
     /// Turn auto scroll on or off.

--- a/src/display.rs
+++ b/src/display.rs
@@ -682,8 +682,8 @@ where
     /// Enable or disable LCD backlight
     pub fn set_backlight(&mut self, backlight: Backlight) {
         match backlight {
-            Backlight::On => self.blink_on(),
-            Backlight::Off => self.blink_off(),
+            Backlight::On => self.backlight_on(),
+            Backlight::Off => self.backlight_off(),
         }
     }
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -60,8 +60,8 @@ where
             InfallibleOutputPin::new(p0),
             InfallibleOutputPin::new(p2),
             delay,
-            InfallibleOutputPin::new(p3),
         )
+        .with_backlight(InfallibleOutputPin::new(p3))
         .with_rw(InfallibleOutputPin::new(p1))
         .with_half_bus(
             InfallibleOutputPin::new(p4),

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -48,7 +48,7 @@ where
     fn from_parts(parts: pcf8574::Parts<'a, I2C, M>, delay: D) -> Self {
         let pcf8574::Parts {
             p0,
-            mut p1,
+            p1,
             p2,
             p3: _,
             p4,
@@ -56,12 +56,12 @@ where
             p6,
             p7,
         } = parts;
-        let _ = p1.set_low();
         LcdDisplay::new(
             InfallibleOutputPin::new(p0),
             InfallibleOutputPin::new(p2),
             delay,
         )
+        .with_rw(InfallibleOutputPin::new(p1))
         .with_half_bus(
             InfallibleOutputPin::new(p4),
             InfallibleOutputPin::new(p5),

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -71,11 +71,13 @@ where
     }
 
     /// Creates a new [`LcdDisplay`] using PCF8572A for interfacing
+    #[inline]
     pub fn new_pcf8574a(expander: &'a mut Pcf8574a<M>, delay: D) -> Self {
         Self::from_parts(expander.split(), delay)
     }
 
     /// Creates a new [`LcdDisplay`] using PCF8572 for interfacing
+    #[inline]
     pub fn new_pcf8574(expander: &'a mut Pcf8574<M>, delay: D) -> Self {
         Self::from_parts(expander.split(), delay)
     }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -50,7 +50,7 @@ where
             p0,
             p1,
             p2,
-            p3: _,
+            p3,
             p4,
             p5,
             p6,
@@ -60,6 +60,7 @@ where
             InfallibleOutputPin::new(p0),
             InfallibleOutputPin::new(p2),
             delay,
+            InfallibleOutputPin::new(p3),
         )
         .with_rw(InfallibleOutputPin::new(p1))
         .with_half_bus(

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -47,6 +47,8 @@ where
     I2C: I2cBus,
     <I2C as I2cBus>::BusError: Debug,
 {
+    /// Descructs pin collection from port expander and constructs LcdDisplay using pins that are
+    /// available.
     fn from_parts(parts: pcf8574::Parts<'a, I2C, M>, delay: D) -> Self {
         let pcf8574::Parts {
             p0,
@@ -74,12 +76,54 @@ where
     }
 
     /// Creates a new [`LcdDisplay`] using PCF8572A for interfacing
+    ///
+    /// Refer to [Pcf8574a docs](https://docs.rs/port-expander/latest/port_expander/dev/pcf8574/struct.Pcf8574a.html) from crate `port-expander` for more information about setup of the port expander
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let peripherals = arduino_hal::Peripherals::take().unwrap();
+    /// let pins = arduino_hal::pins!(peripherals);
+    /// let delay = arduino_hal::Delay::new();
+    ///
+    /// let sda = pins.a4.into_pull_up_input();
+    /// let scl = pins.a5.into_oull_up_input();
+    ///
+    /// let i2c_bus = arduino_hal::i2c::I2c::new(dp.TWI, sda, scl, 50000);
+    /// let mut i2c_expander = Pcf8574a::new(i2c_bus, true, true, true);
+    ///
+    /// let mut lcd: LcdDisplay<_,_> = LcdDisplay::new_pcf8574a(&mut i2c_expander, delay)
+    ///     .with_blink(Blink::On)
+    ///     .with_cursor(Cursor::Off)
+    ///     .build();
+    /// ```
     #[inline]
     pub fn new_pcf8574a(expander: &'a mut Pcf8574a<M>, delay: D) -> Self {
         Self::from_parts(expander.split(), delay)
     }
 
     /// Creates a new [`LcdDisplay`] using PCF8572 for interfacing
+    ///
+    /// Refer to [Pcf8574a docs](https://docs.rs/port-expander/latest/port_expander/dev/pcf8574/struct.Pcf8574.html) from crate `port-expander` for more information about setup of the port expander
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let peripherals = arduino_hal::Peripherals::take().unwrap();
+    /// let pins = arduino_hal::pins!(peripherals);
+    /// let delay = arduino_hal::Delay::new();
+    ///
+    /// let sda = pins.a4.into_pull_up_input();
+    /// let scl = pins.a5.into_oull_up_input();
+    ///
+    /// let i2c_bus = arduino_hal::i2c::I2c::new(dp.TWI, sda, scl, 50000);
+    /// let mut i2c_expander = Pcf8574::new(i2c_bus, true, true, true);
+    ///
+    /// let mut lcd: LcdDisplay<_,_> = LcdDisplay::new_pcf8574a(&mut i2c_expander, delay)
+    ///     .with_blink(Blink::On)
+    ///     .with_cursor(Cursor::Off)
+    ///     .build();
+    /// ```
     #[inline]
     pub fn new_pcf8574(expander: &'a mut Pcf8574<M>, delay: D) -> Self {
         Self::from_parts(expander.split(), delay)

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -51,7 +51,7 @@ where
     <I2C as I2cBus>::BusError: Debug,
 {
     /// Descructs pin collection from port expander and constructs LcdDisplay using pins that are
-    /// available.
+    /// available. For example usage see [`new_pcf8574`] or [`new_pcf8574a`].
     fn from_parts(parts: pcf8574::Parts<'a, I2C, M>, delay: D) -> Self {
         let pcf8574::Parts {
             p0,

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -4,10 +4,7 @@ use core::{
     fmt::Debug,
     ops::{Deref, DerefMut},
 };
-use embedded_hal::{
-    blocking::delay::DelayUs,
-    digital::{v1_compat::OldOutputPin, v2::OutputPin},
-};
+use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 use port_expander::{dev::pcf8574, mode::QuasiBidirectional, I2cBus, Pcf8574a, Pin};
 use shared_bus::{BusMutex, NullMutex};
 
@@ -64,14 +61,15 @@ where
         let mut expander = Pcf8574a::with_mutex(i2c, a0, a1, a2);
         let pcf8574::Parts {
             p0,
-            p1,
+            mut p1,
             p2,
-            p3,
+            p3: _,
             p4,
             p5,
             p6,
             p7,
         } = expander.split();
+        p1.set_low();
         let lcd = LcdDisplay::new(
             InfallibleOutputPin::new(p0),
             InfallibleOutputPin::new(p2),
@@ -103,14 +101,15 @@ where
         let mut expander = Pcf8574a::new(i2c, a0, a1, a2);
         let pcf8574::Parts {
             p0,
-            p1,
+            mut p1,
             p2,
-            p3,
+            p3: _,
             p4,
             p5,
             p6,
             p7,
         } = expander.split();
+        p1.set_low();
         let lcd = LcdDisplay::new(
             InfallibleOutputPin::new(p0),
             InfallibleOutputPin::new(p2),

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -22,6 +22,7 @@ where
     }
 }
 
+/// Wrapper struct to make output pins infallible
 impl<T, E> OutputPin for InfallibleOutputPin<T>
 where
     T: OutputPin<Error = E>,
@@ -29,11 +30,13 @@ where
 {
     type Error = Infallible;
 
+    /// Set this output pin to low
     fn set_low(&mut self) -> Result<(), Self::Error> {
         let _ = self.pin.set_low();
         Ok(())
     }
 
+    /// Set this output pin to high
     fn set_high(&mut self) -> Result<(), Self::Error> {
         let _ = self.pin.set_high();
         Ok(())

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -61,6 +61,8 @@ where
     I2C: I2cBus,
     <I2C as I2cBus>::BusError: Debug,
 {
+    /// Creates a new [`I2CLcdDisplay`] using PCF8572A for interfacing and selected mutex
+    /// [`init_lcd`] must be called after before any otehr use
     pub fn new_pcf8574a_with_mutex(i2c: I2C, a0: bool, a1: bool, a2: bool) -> Self {
         let expander = Pcf8574a::with_mutex(i2c, a0, a1, a2);
         Self {
@@ -69,6 +71,7 @@ where
         }
     }
 
+    /// Initializes lcd, no lcd methods should be used before a call to this method!
     pub fn init_lcd(&'a mut self, delay: D) {
         let pcf8574::Parts {
             p0,
@@ -107,6 +110,8 @@ where
     I2C: I2cBus,
     <I2C as I2cBus>::BusError: Debug,
 {
+    /// Creates a new [`I2CLcdDisplay`] using PCF8572A for interfacing and default mutex
+    /// [`init_lcd`] must be called after before any otehr use
     pub fn new_pcf8574a(i2c: I2C, a0: bool, a1: bool, a2: bool) -> Self {
         let expander = Pcf8574a::new(i2c, a0, a1, a2);
         Self {

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -11,7 +11,7 @@ use shared_bus::{BusMutex, NullMutex};
 
 /// Custom version of OldOutputPin that implements v2::OutputPin
 /// Used to convert pin with fallible error to infallible
-struct InfallibleOutputPin<T> {
+pub struct InfallibleOutputPin<T> {
     pin: T,
 }
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -45,8 +45,7 @@ where
     I2C: I2cBus,
     <I2C as I2cBus>::BusError: Debug,
 {
-    /// Creates a new [`LcdDisplay`] using PCF8572A for interfacing
-    pub fn new_pcf8574a(expander: &'a mut Pcf8574a<M>, delay: D) -> Self {
+    fn from_parts(parts: pcf8574::Parts<'a, I2C, M>, delay: D) -> Self {
         let pcf8574::Parts {
             p0,
             mut p1,
@@ -56,7 +55,7 @@ where
             p5,
             p6,
             p7,
-        } = expander.split();
+        } = parts;
         let _ = p1.set_low();
         LcdDisplay::new(
             InfallibleOutputPin::new(p0),
@@ -71,29 +70,13 @@ where
         )
     }
 
+    /// Creates a new [`LcdDisplay`] using PCF8572A for interfacing
+    pub fn new_pcf8574a(expander: &'a mut Pcf8574a<M>, delay: D) -> Self {
+        Self::from_parts(expander.split(), delay)
+    }
+
     /// Creates a new [`LcdDisplay`] using PCF8572 for interfacing
     pub fn new_pcf8574(expander: &'a mut Pcf8574<M>, delay: D) -> Self {
-        let pcf8574::Parts {
-            p0,
-            mut p1,
-            p2,
-            p3: _,
-            p4,
-            p5,
-            p6,
-            p7,
-        } = expander.split();
-        let _ = p1.set_low();
-        LcdDisplay::new(
-            InfallibleOutputPin::new(p0),
-            InfallibleOutputPin::new(p2),
-            delay,
-        )
-        .with_half_bus(
-            InfallibleOutputPin::new(p4),
-            InfallibleOutputPin::new(p5),
-            InfallibleOutputPin::new(p6),
-            InfallibleOutputPin::new(p7),
-        )
+        Self::from_parts(expander.split(), delay)
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -17,12 +17,12 @@ where
     T: OutputPin<Error = E>,
     E: Debug,
 {
+    /// Wraps any OutputPin to make a struct implementing OutputPin<Error=Infallible>
     fn new(pin: T) -> Self {
         Self { pin }
     }
 }
 
-/// Wrapper struct to make output pins infallible
 impl<T, E> OutputPin for InfallibleOutputPin<T>
 where
     T: OutputPin<Error = E>,

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,8 +1,47 @@
 use crate::LcdDisplay;
-use core::convert::Infallible;
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
-use port_expander::{dev::pcf8574, I2cBus, Pcf8574a};
+use core::{
+    convert::Infallible,
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
+use embedded_hal::{
+    blocking::delay::DelayUs,
+    digital::{v1_compat::OldOutputPin, v2::OutputPin},
+};
+use port_expander::{dev::pcf8574, mode::QuasiBidirectional, I2cBus, Pcf8574a, Pin};
 use shared_bus::{BusMutex, NullMutex};
+
+/// Custom version of OldOutputPin that implements v2::OutputPin
+/// Used to convert pin with fallible error to infallible
+struct InfallibleOutputPin<T> {
+    pin: T,
+}
+
+impl<T, E> InfallibleOutputPin<T>
+where
+    T: OutputPin<Error = E>,
+    E: Debug,
+{
+    fn new(pin: T) -> Self {
+        Self { pin }
+    }
+}
+
+impl<T, E> OutputPin for InfallibleOutputPin<T>
+where
+    T: OutputPin<Error = E>,
+    E: Debug,
+{
+    type Error = Infallible;
+
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        Ok(self.pin.set_low().unwrap())
+    }
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        Ok(self.pin.set_high().unwrap())
+    }
+}
 
 /// Uses port expander, like PCF8574, to communicate with display
 pub struct I2CLcdDisplay<T, D, E>
@@ -14,12 +53,12 @@ where
     expander: E,
 }
 
-impl<T, D, M, I2C> I2CLcdDisplay<T, D, Pcf8574a<M>>
+impl<D, M, I2C> I2CLcdDisplay<InfallibleOutputPin<Pin<'_, QuasiBidirectional, M>>, D, Pcf8574a<M>>
 where
-    T: OutputPin<Error = Infallible> + Sized,
     D: DelayUs<u16> + Sized,
     M: BusMutex<Bus = pcf8574::Driver<I2C>>,
     I2C: I2cBus,
+    <I2C as I2cBus>::BusError: Debug,
 {
     pub fn new_pcf8574a_with_mutex(i2c: I2C, a0: bool, a1: bool, a2: bool, delay: D) -> Self {
         let mut expander = Pcf8574a::with_mutex(i2c, a0, a1, a2);
@@ -33,18 +72,32 @@ where
             p6,
             p7,
         } = expander.split();
-        let lcd = LcdDisplay::new(p0, p2, delay)
-            .with_half_bus(p4, p5, p6, p7)
-            .build();
+        let lcd = LcdDisplay::new(
+            InfallibleOutputPin::new(p0),
+            InfallibleOutputPin::new(p2),
+            delay,
+        )
+        .with_half_bus(
+            InfallibleOutputPin::new(p4),
+            InfallibleOutputPin::new(p5),
+            InfallibleOutputPin::new(p6),
+            InfallibleOutputPin::new(p7),
+        )
+        .build();
         Self { lcd, expander }
     }
 }
 
-impl<T, D, I2C> I2CLcdDisplay<T, D, Pcf8574a<NullMutex<pcf8574::Driver<I2C>>>>
+impl<D, I2C>
+    I2CLcdDisplay<
+        InfallibleOutputPin<Pin<'_, QuasiBidirectional, NullMutex<pcf8574::Driver<I2C>>>>,
+        D,
+        Pcf8574a<NullMutex<pcf8574::Driver<I2C>>>,
+    >
 where
-    T: OutputPin<Error = Infallible> + Sized,
     D: DelayUs<u16> + Sized,
     I2C: I2cBus,
+    <I2C as I2cBus>::BusError: Debug,
 {
     pub fn new_pcf8574a(i2c: I2C, a0: bool, a1: bool, a2: bool, delay: D) -> Self {
         let mut expander = Pcf8574a::new(i2c, a0, a1, a2);
@@ -58,9 +111,40 @@ where
             p6,
             p7,
         } = expander.split();
-        let lcd = LcdDisplay::new(p0, p2, delay)
-            .with_half_bus(p4, p5, p6, p7)
-            .build();
+        let lcd = LcdDisplay::new(
+            InfallibleOutputPin::new(p0),
+            InfallibleOutputPin::new(p2),
+            delay,
+        )
+        .with_half_bus(
+            InfallibleOutputPin::new(p4),
+            InfallibleOutputPin::new(p5),
+            InfallibleOutputPin::new(p6),
+            InfallibleOutputPin::new(p7),
+        )
+        .build();
         Self { lcd, expander }
+    }
+}
+
+impl<T, D, E> Deref for I2CLcdDisplay<T, D, E>
+where
+    T: OutputPin<Error = Infallible> + Sized,
+    D: DelayUs<u16> + Sized,
+{
+    type Target = LcdDisplay<T, D>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.lcd
+    }
+}
+
+impl<T, D, E> DerefMut for I2CLcdDisplay<T, D, E>
+where
+    T: OutputPin<Error = Infallible> + Sized,
+    D: DelayUs<u16> + Sized,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.lcd
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,0 +1,66 @@
+use crate::LcdDisplay;
+use core::convert::Infallible;
+use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use port_expander::{dev::pcf8574, I2cBus, Pcf8574a};
+use shared_bus::{BusMutex, NullMutex};
+
+/// Uses port expander, like PCF8574, to communicate with display
+pub struct I2CLcdDisplay<T, D, E>
+where
+    T: OutputPin<Error = Infallible> + Sized,
+    D: DelayUs<u16> + Sized,
+{
+    lcd: LcdDisplay<T, D>,
+    expander: E,
+}
+
+impl<T, D, M, I2C> I2CLcdDisplay<T, D, Pcf8574a<M>>
+where
+    T: OutputPin<Error = Infallible> + Sized,
+    D: DelayUs<u16> + Sized,
+    M: BusMutex<Bus = pcf8574::Driver<I2C>>,
+    I2C: I2cBus,
+{
+    pub fn new_pcf8574a_with_mutex(i2c: I2C, a0: bool, a1: bool, a2: bool, delay: D) -> Self {
+        let mut expander = Pcf8574a::with_mutex(i2c, a0, a1, a2);
+        let pcf8574::Parts {
+            p0,
+            p1,
+            p2,
+            p3,
+            p4,
+            p5,
+            p6,
+            p7,
+        } = expander.split();
+        let lcd = LcdDisplay::new(p0, p2, delay)
+            .with_half_bus(p4, p5, p6, p7)
+            .build();
+        Self { lcd, expander }
+    }
+}
+
+impl<T, D, I2C> I2CLcdDisplay<T, D, Pcf8574a<NullMutex<pcf8574::Driver<I2C>>>>
+where
+    T: OutputPin<Error = Infallible> + Sized,
+    D: DelayUs<u16> + Sized,
+    I2C: I2cBus,
+{
+    pub fn new_pcf8574a(i2c: I2C, a0: bool, a1: bool, a2: bool, delay: D) -> Self {
+        let mut expander = Pcf8574a::new(i2c, a0, a1, a2);
+        let pcf8574::Parts {
+            p0,
+            p1,
+            p2,
+            p3,
+            p4,
+            p5,
+            p6,
+            p7,
+        } = expander.split();
+        let lcd = LcdDisplay::new(p0, p2, delay)
+            .with_half_bus(p4, p5, p6, p7)
+            .build();
+        Self { lcd, expander }
+    }
+}

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,3 +1,5 @@
+//! Allows interacting  with an lcd display via I2C using a digital port expander
+
 use crate::LcdDisplay;
 use core::{convert::Infallible, fmt::Debug};
 use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,6 @@
 
 mod display;
 mod errors;
-/// Allows interacting  with an lcd display via I2C using a digital port expander
 #[cfg(feature = "i2c")]
 pub mod i2c;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@
 mod display;
 mod errors;
 /// Allows interacting  with an lcd display via I2C using a digital port expander
+#[cfg(feature = "i2c")]
 pub mod i2c;
 
 pub use display::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,8 @@
 
 mod display;
 mod errors;
-mod i2c;
+/// Allows interacting  with an lcd display via I2C using a digital port expander
+pub mod i2c;
 
 pub use display::*;
 pub use errors::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@
 
 mod display;
 mod errors;
+mod i2c;
 
 pub use display::*;
 pub use errors::Error;


### PR DESCRIPTION
Resolves #22 

This implementation uses [port-expander](https://docs.rs/port-expander/latest/port_expander/index.html) crate to interface with LCD, half-bus mode. It is planned to support all port expander models that are available for such an lcd, currently known to me are PCF8574 and PCF8574A, both are supported by the aforementioned crate.