### PR TITLE
Relax requirements of OutputPin error type

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -1,5 +1,4 @@
 use crate::Error;
-use core::convert::Infallible;
 use embedded_hal::blocking::delay::DelayUs;
 use embedded_hal::digital::v2::OutputPin;
 
@@ -162,7 +161,7 @@ const A: u8 = 11;
 /// misconfigured.
 pub struct LcdDisplay<T, D>
 where
-    T: OutputPin<Error = Infallible> + Sized,
+    T: OutputPin + Sized,
     D: DelayUs<u16> + Sized,
 {
     pins: [Option<T>; 12],
@@ -176,7 +175,7 @@ where
 
 impl<T, D> LcdDisplay<T, D>
 where
-    T: OutputPin<Error = Infallible> + Sized,
+    T: OutputPin + Sized,
     D: DelayUs<u16> + Sized,
 {
     /// Create a new instance of the LcdDisplay

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,47 +1,10 @@
 //! Allows interacting  with an lcd display via I2C using a digital port expander
 
 use crate::LcdDisplay;
-use core::{convert::Infallible, fmt::Debug};
-use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
+use core::fmt::Debug;
+use embedded_hal::blocking::delay::DelayUs;
 use port_expander::{dev::pcf8574, mode::QuasiBidirectional, I2cBus, Pcf8574, Pcf8574a, Pin};
 use shared_bus::BusMutex;
-
-/// Custom version of OldOutputPin that implements v2::OutputPin
-/// Used to convert pin with fallible error to infallible
-pub struct InfallibleOutputPin<T> {
-    pin: T,
-}
-
-impl<T, E> InfallibleOutputPin<T>
-where
-    T: OutputPin<Error = E>,
-    E: Debug,
-{
-    /// Wraps any OutputPin to make a struct implementing OutputPin<Error=Infallible>
-    fn new(pin: T) -> Self {
-        Self { pin }
-    }
-}
-
-impl<T, E> OutputPin for InfallibleOutputPin<T>
-where
-    T: OutputPin<Error = E>,
-    E: Debug,
-{
-    type Error = Infallible;
-
-    /// Set this output pin to low
-    fn set_low(&mut self) -> Result<(), Self::Error> {
-        let _ = self.pin.set_low();
-        Ok(())
-    }
-
-    /// Set this output pin to high
-    fn set_high(&mut self) -> Result<(), Self::Error> {
-        let _ = self.pin.set_high();
-        Ok(())
-    }
-}
 
 impl<'a, D, M, I2C> LcdDisplay<Pin<'a, QuasiBidirectional, M>, D>
 where

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -43,7 +43,7 @@ where
     }
 }
 
-impl<'a, D, M, I2C> LcdDisplay<InfallibleOutputPin<Pin<'a, QuasiBidirectional, M>>, D>
+impl<'a, D, M, I2C> LcdDisplay<Pin<'a, QuasiBidirectional, M>, D>
 where
     D: DelayUs<u16> + Sized,
     M: BusMutex<Bus = pcf8574::Driver<I2C>>,
@@ -63,19 +63,10 @@ where
             p6,
             p7,
         } = parts;
-        LcdDisplay::new(
-            InfallibleOutputPin::new(p0),
-            InfallibleOutputPin::new(p2),
-            delay,
-        )
-        .with_backlight(InfallibleOutputPin::new(p3))
-        .with_rw(InfallibleOutputPin::new(p1))
-        .with_half_bus(
-            InfallibleOutputPin::new(p4),
-            InfallibleOutputPin::new(p5),
-            InfallibleOutputPin::new(p6),
-            InfallibleOutputPin::new(p7),
-        )
+        LcdDisplay::new(p0, p2, delay)
+            .with_backlight(p3)
+            .with_rw(p1)
+            .with_half_bus(p4, p5, p6, p7)
     }
 
     /// Creates a new [`LcdDisplay`] using PCF8572A for interfacing


### PR DESCRIPTION
Resolves #32 

All I did is removed requirement of `OutputPin<Error = Infallible>` and removed the wrapper pin in i2c module.

Making i2c impl blocks more generic wouldn't work (and probably would have no benefit) since both supported i2c expanders have the same `Pin` struct.