### PR TITLE
Add I2C example, fix error in doc strings, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ complicated to use. This library uses traits from [embedded-hal](https://crates.
 with any hardware abstraction layer that uses the same types. Currently this crate has only been tested with [avr-hal](https://github.com/Rahix/avr-hal)
 and all example code and comments assume you're using avr-hal as well.
 
+Functionality for controlling the LCD via I2C using a PCF8574 or a PCF8574A remote I/O expander is also available.
+
 ## Building
 
 You'll need to use nightly to compile this project because avr-hal requires nightly-2021-01-07 or older.
@@ -28,6 +30,8 @@ NOTE: all examples have been updated to use `nightly-2022-07-10` and manually te
 ## Usage
 
 ```rust
+// Without I2C
+
 use ag_lcd::{Display, Blink, Cursor, LcdDisplay};
 
 let peripherals = arduino_hal::Peripherals::take().unwrap();
@@ -57,6 +61,31 @@ let mut lcd: LcdDisplay<_,_> = LcdDisplay::new(rs, en, delay)
 
 lcd.set_cursor(Cursor::Off);
 lcd.set_blink(Blink::Off);
+
+lcd.print("Test message!");
+```
+
+```rust
+// With I2C
+
+use ag_lcd::{Cursor, LcdDisplay};
+use panic_halt as _;
+use port_expander::dev::pcf8574::Pcf8574;
+
+
+let peripherals = arduino_hal::Peripherals::take().unwrap();
+let pins = arduino_hal::pins!(peripherals);
+let delay = arduino_hal::Delay::new();
+
+let sda = pins.a4.into_pull_up_input();
+let scl = pins.a5.into_pull_up_input();
+
+let i2c_bus = arduino_hal::i2c::I2c::new(peripherals.TWI, sda, scl, 50000);
+let mut i2c_expander = Pcf8574::new(i2c_bus, true, true, true);
+
+let mut lcd: LcdDisplay<_, _> = LcdDisplay::new_pcf8574(&mut i2c_expander, delay)
+    .with_cursor(Cursor::Off)
+    .build();
 
 lcd.print("Test message!");
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # AG-LCD Examples
 
-All examples assume: 
+## All non-I2C examples assume:
 
 * A HD44780 two-line LCD screen 
 * An Arduino Nano for examples in directory `nano/`, and an Arduino Uno for examples in directory `uno/`
@@ -27,6 +27,21 @@ Pins should be connected as follows (optional pins are commented in examples):
 | d3      | D6       | YES      |
 | d2      | D7       | YES      |
 
+## I2C examples assume:
+
+* A PCF8574 or a PCF8574A remote I/O expander
+* A HD44780 two-line LCD screen
+* An Arduino Nano for examples in directory `nano/`, and an Arduino Uno for examples in directory `uno/`
+
+Pins should be connected as follows:
+
+| Arduino | I/O Expander |
+|---------|--------------|
+| GND     | GND          |
+| VCC     | 5V           |
+| A4      | SDA          |
+| A5      | SCL          |
+
 # Running
 
 * You'll need [ravedude](https://crates.io/crates/ravedude) installed. You can do that by following their installation instructions for your system.
@@ -36,4 +51,4 @@ Pins should be connected as follows (optional pins are commented in examples):
 # Troubleshooting
 * If your using a Nano board and recieve `avrdude: stk500_getsync() attempt 1 of 10: not in sync: resp=0x00` upon running `cargo run`, it might be because your board was manufactured after January 2018. In that case you'll need the new boot loader, which is achieved by changing `nano` to `nano-new` for `runner` in `.cargo/config.toml` in the example directory.
 * Regarding Arduino Uno: only setups using required pins have been tested to work
-* Some users have reported issues with initializing the LCD: try using the builder method `with_reliable_init()`, and see `examples/uno/two_lines/` for an example that implements it (see [#4](https://github.com/mjhouse/ag-lcd/issues/4) for further discussion).
+* Some users have reported issues with initializing the LCD when not using I2C: try using the builder method `with_reliable_init()`, and see `examples/uno/two_lines/` for an example that implements it (see [#4](https://github.com/mjhouse/ag-lcd/issues/4) for further discussion).

--- a/examples/nano/i2c-print/.cargo/config.toml
+++ b/examples/nano/i2c-print/.cargo/config.toml
@@ -1,0 +1,9 @@
+[build]
+target = "avr-specs/avr-atmega328p.json"
+
+# add something like --port=/dev/ttyUSB0 to target device
+[target.'cfg(target_arch = "avr")']
+runner = "ravedude nano-new -cb 57600"
+
+[unstable]
+build-std = ["core"]

--- a/examples/nano/i2c-print/Cargo.toml
+++ b/examples/nano/i2c-print/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "ag-lcd-i2c-print"
+version = "0.2.0"
+authors = ["Victor Nilsson @vcrn"]
+description = "An example of the ag-lcd library"
+repository = "https://github.com/mjhouse/ag-lcd"
+license = "GPL-3.0-or-later"
+edition = "2021"
+readme = "README.md"
+
+[dependencies]
+arduino-hal = { git = "https://github.com/rahix/avr-hal", rev = "84af1c72693893449cf93b6a4449df58c57c21e6", features = ["arduino-nano"] }
+ag-lcd = { path = "../../../", features = ["i2c"] }
+panic-halt = "0.2.0"
+port-expander = "0.3.0"
+
+[profile.dev]
+panic = "abort"
+lto = true
+opt-level = "s"
+
+[profile.release]
+panic = "abort"
+codegen-units = 1
+debug = true
+lto = true
+opt-level = "s"

--- a/examples/nano/i2c-print/README.md
+++ b/examples/nano/i2c-print/README.md
@@ -1,0 +1,5 @@
+## Nano ([code](src/main.rs))
+
+`cd examples/nano/i2c-print && cargo run`  
+
+Displays "Hello, world" on an Arduino Nano

--- a/examples/nano/i2c-print/avr-specs/avr-atmega328p.json
+++ b/examples/nano/i2c-print/avr-specs/avr-atmega328p.json
@@ -1,0 +1,27 @@
+{
+  "arch": "avr",
+  "atomic-cas": false,
+  "cpu": "atmega328p",
+  "data-layout": "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
+  "eh-frame-header": false,
+  "exe-suffix": ".elf",
+  "executables": true,
+  "late-link-args": {
+    "gcc": [
+      "-lgcc"
+    ]
+  },
+  "linker": "avr-gcc",
+  "linker-is-gnu": true,
+  "llvm-target": "avr-unknown-unknown",
+  "max-atomic-width": 8,
+  "no-default-libraries": false,
+  "pre-link-args": {
+    "gcc": [
+      "-mmcu=atmega328p",
+      "-Wl,--as-needed"
+    ]
+  },
+  "target-c-int-width": "16",
+  "target-pointer-width": "16"
+}

--- a/examples/nano/i2c-print/rust-toolchain.toml
+++ b/examples/nano/i2c-print/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2022-07-10"
+components = [ "rust-src" ]
+profile = "minimal"

--- a/examples/nano/i2c-print/src/main.rs
+++ b/examples/nano/i2c-print/src/main.rs
@@ -1,0 +1,27 @@
+#![no_std]
+#![no_main]
+
+use ag_lcd::{Cursor, LcdDisplay};
+use panic_halt as _;
+use port_expander::dev::pcf8574::Pcf8574;
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+    let delay = arduino_hal::Delay::new();
+
+    let sda = pins.a4.into_pull_up_input();
+    let scl = pins.a5.into_pull_up_input();
+
+    let i2c_bus = arduino_hal::i2c::I2c::new(dp.TWI, sda, scl, 50000);
+    let mut i2c_expander = Pcf8574::new(i2c_bus, true, true, true);
+
+    let mut lcd: LcdDisplay<_, _> = LcdDisplay::new_pcf8574(&mut i2c_expander, delay)
+        .with_cursor(Cursor::Off)
+        .build();
+
+    lcd.print("Hello, World");
+
+    loop {}
+}

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -44,9 +44,9 @@ where
     /// let delay = arduino_hal::Delay::new();
     ///
     /// let sda = pins.a4.into_pull_up_input();
-    /// let scl = pins.a5.into_oull_up_input();
+    /// let scl = pins.a5.into_pull_up_input();
     ///
-    /// let i2c_bus = arduino_hal::i2c::I2c::new(dp.TWI, sda, scl, 50000);
+    /// let i2c_bus = arduino_hal::i2c::I2c::new(peripherals.TWI, sda, scl, 50000);
     /// let mut i2c_expander = Pcf8574a::new(i2c_bus, true, true, true);
     ///
     /// let mut lcd: LcdDisplay<_,_> = LcdDisplay::new_pcf8574a(&mut i2c_expander, delay)
@@ -71,9 +71,9 @@ where
     /// let delay = arduino_hal::Delay::new();
     ///
     /// let sda = pins.a4.into_pull_up_input();
-    /// let scl = pins.a5.into_oull_up_input();
+    /// let scl = pins.a5.into_pull_up_input();
     ///
-    /// let i2c_bus = arduino_hal::i2c::I2c::new(dp.TWI, sda, scl, 50000);
+    /// let i2c_bus = arduino_hal::i2c::I2c::new(peripherals.TWI, sda, scl, 50000);
     /// let mut i2c_expander = Pcf8574::new(i2c_bus, true, true, true);
     ///
     /// let mut lcd: LcdDisplay<_,_> = LcdDisplay::new_pcf8574a(&mut i2c_expander, delay)


### PR DESCRIPTION
My intention for this PR was to just fix some small typos/errors in the docs strings in `src/i2c.rs` which I found when trying out the code. But since I had a simple working example by that point, I thought I'd might as well add that example  to the PR. I also updated some of the READMEs while I was at it. So it expanded a bit from my original intention with the PR.

We might want to add more info in the root README since this crate is starting to feel less like a pure port of the `LiquidCrystal` lib, and mentioning the need for adding "i2c" as a feature for the `ag-lcd` dependency in `Cargo.toml` when using this crate. But that's probably better to take in another PR.