### PR TITLE
Qualify `Infallible` error type, fixing build with `ufmt` feature

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -1252,10 +1252,10 @@ where
 #[cfg(feature = "ufmt")]
 impl<T, D> ufmt::uWrite for LcdDisplay<T, D>
 where
-    T: OutputPin<Error = Infallible> + Sized,
+    T: OutputPin<Error = core::convert::Infallible> + Sized,
     D: DelayUs<u16> + Sized,
 {
-    type Error = Infallible;
+    type Error = core::convert::Infallible;
 
     fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
         self.print(s);


### PR DESCRIPTION
Hello,

I noticed that in v0.2.0 the "ufmt" feature is broken because of an unqualified use of `Infallible` in the absence of `use core::convert::Infallible;`. This PR corrects this by fully qualifying it. My guess is that there once was a `use` which was later removed as it is not necessary when the "ufmt" feature is not enabled. I would suggest to add a GitHub actions workflow which runs `cargo build --all-features` to avoid this in the future.